### PR TITLE
Test should use empty object

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -5,7 +5,8 @@ test('shallow Objects get merged', ({ expect }) => {
   const obj1 = { count: 1, color: 'green' }
   const obj2 = { count: 1, shape: 'triangle' }
   const obj3 = { count: 1, size: 'large' }
-  expect(merge({}, obj1, obj2, obj3)).toStrictEqual({ ...obj1, ...obj2, ...obj3 })
+  expect(merge({}, obj1, obj2, obj3))
+    .toStrictEqual({ ...obj1, ...obj2, ...obj3 })
 })
 
 test('nested Objects get merged', ({ expect }) => {

--- a/tests.js
+++ b/tests.js
@@ -5,7 +5,7 @@ test('shallow Objects get merged', ({ expect }) => {
   const obj1 = { count: 1, color: 'green' }
   const obj2 = { count: 1, shape: 'triangle' }
   const obj3 = { count: 1, size: 'large' }
-  expect(merge(obj1, obj2, obj3)).toEqual({ ...obj1, ...obj2, ...obj3 })
+  expect(merge({}, obj1, obj2, obj3)).toEqual({ ...obj1, ...obj2, ...obj3 })
 })
 
 test('nested Objects get merged', ({ expect }) => {


### PR DESCRIPTION
Though this test is passing bc { ...obj1, ...obj2, ...obj3 } == obj1 after the merge() mutates obj1, I don't believe that's what the test is aiming for.

You can confirm by swapping out the expect with: `expect(merge(obj1, obj2, obj3)).toEqual(obj1)` which will pass along with `expect(merge(obj1, obj2, obj3)).toEqual({ ...obj1, ...obj2, ...obj3 })` which is probably not intended